### PR TITLE
Require Sylius 1.10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "friendsofsymfony/oauth-server-bundle": ">2.0.0-alpha.0 ^2.0@dev",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.1.3",
         "sylius-labs/polyfill-symfony-framework-bundle": "^1.0",
-        "sylius/sylius": "^1.9",
+        "sylius/sylius": "^1.10",
         "symfony/form": "^4.4 || ^5.2",
         "symfony/framework-bundle": "^4.4 || ^5.2",
         "symfony/validator": "^4.4 || ^5.2"


### PR DESCRIPTION
Shouldn't it rely on 1.10, and not 1.9 ? having difficulties trying to install the beta version of Sylius/Sylius