### PR TITLE
Add PHP 8.0 support to composer.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4]
+                php: [7.4, 8.0]
                 symfony: [^4.4, ^5.2]
-                sylius: [~1.9.0]
+                sylius: [~1.10.0]
                 node: [10.x]
                 mysql: [5.7]
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 | ^8.0",
         "friendsofsymfony/oauth-server-bundle": ">2.0.0-alpha.0 ^2.0@dev",
         "sylius-labs/doctrine-migrations-extra-bundle": "^0.1.3",
         "sylius-labs/polyfill-symfony-framework-bundle": "^1.0",


### PR DESCRIPTION
If we want to upgrade to Sylius 1.10.0 and keep the Sylius Admin Api bundle (point one in the upgrade guide https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.10.md) while running it on PHP 8.0 we need this change in composer.json. 