### PR TITLE
Fix broken tests

### DIFF
--- a/Form/Type/OrderType.php
+++ b/Form/Type/OrderType.php
@@ -38,8 +38,8 @@ final class OrderType extends AbstractResourceType
 
     public function __construct(
         string $dataClass,
-        array $validationGroups = [],
         RepositoryInterface $localeRepository,
+        array $validationGroups = [],
         ?ChoiceLoaderInterface $customerChoiceLoader = null
     ) {
         parent::__construct($dataClass, $validationGroups);

--- a/Resources/config/services/form.xml
+++ b/Resources/config/services/form.xml
@@ -36,8 +36,8 @@
 
         <service id="sylius.form.type.api_order" class="Sylius\Bundle\AdminApiBundle\Form\Type\OrderType">
             <argument>%sylius.model.order.class%</argument>
-            <argument>%sylius.form.type.api_order.validation_groups%</argument>
             <argument type="service" id="sylius.repository.locale" />
+            <argument>%sylius.form.type.api_order.validation_groups%</argument>
             <argument type="service" id="sylius.form.choice_list.loader.lazy_customer_loader" />
             <tag name="form.type" />
         </service>

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
         "twig/twig": "^2.12",
         "vimeo/psalm": "4.6.4"
     },
+    "conflict": {
+        "doctrine/dbal": "^3"
+    },
     "config": {
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
         "vimeo/psalm": "4.6.4"
     },
     "conflict": {
-        "doctrine/dbal": "^3"
+        "doctrine/dbal": "^3",
+        "friendsofsymfony/rest-bundle": "^3.1"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
     },
     "conflict": {
         "doctrine/dbal": "^3",
+        "doctrine/orm": "^2.10",
         "friendsofsymfony/rest-bundle": "^3.1"
     },
     "config": {


### PR DESCRIPTION
The exception normalizing/flattening behavior has changed in 3.1.0 causing exceptions to be rendered as RFC 7807 type responses instead of the legacy output that the tests expect.

https://github.com/FriendsOfSymfony/FOSRestBundle/compare/3.0.5..3.1.0

Serializer/Normalizer/FlattenExceptionNormalizer.php around line 78.

That is causing the tests to fail along with DBAL v3 no longer supporting the `json_array` type that Sylius uses.
Introducing these conflicts solves the problems for now.