### PR TITLE
Change branch alias to 1.11-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.10-dev"
+            "dev-master": "1.11-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/Sylius/SyliusAdminApiBundle/issues/13), something wrong happened with the versioning of this package 😨 To be honest, I have no idea what 😅 There is not much we can do about it 🤷‍♂️  Therefore, I propose the next version would be 1.11.0, with Sylius 1.10 support. The next one will be 1.12.0, with the support for Sylius 1.11 added.

🖖 